### PR TITLE
fix(release-cli): add create/delete/values commands

### DIFF
--- a/cmd/release-cli/create.go
+++ b/cmd/release-cli/create.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"github.com/caicloud/clientset/kubernetes"
+	"github.com/caicloud/clientset/pkg/apis/release/v1alpha1"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
+)
+
+func init() {
+	root.AddCommand(create)
+	fs := create.Flags()
+
+	fs.StringVarP(&createOptions.Server, "server", "s", "", "Kubenetes master host")
+	fs.StringVarP(&createOptions.BearerToken, "bearer-token", "b", "", "Kubenetes master bearer token")
+	fs.StringVarP(&createOptions.Namespace, "namespace", "n", "", "Kubenetes namespace")
+	fs.StringVarP(&createOptions.Values, "values", "c", "", "Chart values file path. Override values.yaml in template")
+	fs.StringVarP(&createOptions.Template, "template", "t", "", "Chart template file path. Can be a tgz package or a chart directory")
+}
+
+var createOptions = struct {
+	Server      string
+	BearerToken string
+	Namespace   string
+	Values      string
+	Template    string
+}{}
+
+var create = &cobra.Command{
+	Use:   "create",
+	Short: "Create a release into kubernetes cluster",
+	Run:   runCreate,
+}
+
+func runCreate(cmd *cobra.Command, args []string) {
+	if createOptions.Server == "" || createOptions.BearerToken == "" {
+		glog.Fatalln("--server and --bearer-token must be set")
+	}
+
+	if createOptions.Namespace == "" {
+		glog.Fatalln("--namespace must be set")
+	}
+
+	if createOptions.Template == "" {
+		glog.Fatalln("--template must be set")
+	}
+
+	if len(args) <= 0 {
+		glog.Fatalln("Must specify release name")
+	}
+	if len(args) > 1 {
+		glog.Fatalln("Two or more release names is not allowed")
+	}
+
+	template, config, err := loadChart(createOptions.Template, createOptions.Values)
+	if err != nil {
+		glog.Fatalf("Unable to load template and values: %v", err)
+	}
+	clientset, err := kubernetes.NewForConfig(&rest.Config{
+		Host:        createOptions.Server,
+		BearerToken: createOptions.BearerToken,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true,
+		},
+	})
+	if err != nil {
+		glog.Fatalln(err)
+	}
+	rel := &v1alpha1.Release{}
+	rel.Name = args[0]
+	rel.Spec.Config = config
+	rel.Spec.Template = template
+	r, err := clientset.ReleaseV1alpha1().Releases(createOptions.Namespace).Create(rel)
+	if err != nil {
+		glog.Fatalln(err)
+	}
+	meta := [][]string{
+		{"Name:", r.Name},
+		{"Namespace:", r.Namespace},
+		{"Start Time:", r.CreationTimestamp.String()},
+	}
+	printTable(meta)
+}

--- a/cmd/release-cli/delete.go
+++ b/cmd/release-cli/delete.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/caicloud/clientset/kubernetes"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
+)
+
+func init() {
+	root.AddCommand(delete)
+	fs := delete.Flags()
+
+	fs.StringVarP(&deleteOptions.Server, "server", "s", "", "Kubenetes master host")
+	fs.StringVarP(&deleteOptions.BearerToken, "bearer-token", "b", "", "Kubenetes master bearer token")
+	fs.StringVarP(&deleteOptions.Namespace, "namespace", "n", "", "Kubenetes namespace")
+}
+
+var deleteOptions = struct {
+	Server      string
+	BearerToken string
+	Namespace   string
+}{}
+
+var delete = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a release from kubernetes cluster",
+	Run:   runDelete,
+}
+
+func runDelete(cmd *cobra.Command, args []string) {
+	if deleteOptions.Server == "" || deleteOptions.BearerToken == "" {
+		glog.Fatalln("--server and --bearer-token must be set")
+	}
+
+	if deleteOptions.Namespace == "" {
+		glog.Fatalln("--namespace must be set")
+	}
+
+	if len(args) <= 0 {
+		glog.Fatalln("Must specify release name")
+	}
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{
+		Host:        deleteOptions.Server,
+		BearerToken: deleteOptions.BearerToken,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true,
+		},
+	})
+	if err != nil {
+		glog.Fatalln(err)
+	}
+
+	for _, name := range args {
+		err := clientset.ReleaseV1alpha1().Releases(deleteOptions.Namespace).Delete(name, nil)
+		if err != nil {
+			glog.Fatalln(err)
+		}
+		fmt.Printf("%s deleted\n", name)
+	}
+}

--- a/cmd/release-cli/util.go
+++ b/cmd/release-cli/util.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+	"k8s.io/helm/pkg/chartutil"
+	"k8s.io/helm/pkg/proto/hapi/chart"
+)
+
+func loadChart(template string, values string) ([]byte, string, error) {
+	chart, err := chartutil.Load(template)
+	if err != nil {
+		return nil, "", err
+	}
+	config := ""
+	if values != "" {
+		cfg, err := ioutil.ReadFile(values)
+		if err != nil {
+			return nil, "", err
+		}
+		config = string(cfg)
+	} else {
+		config = chart.Values.Raw
+	}
+	chart.Values = nil
+	tpl, err := archive(chart)
+	if err != nil {
+		return nil, "", err
+	}
+	return tpl, config, nil
+}
+
+// zipper header
+var headerBytes = []byte("+aHR0cHM6Ly95b3V0dS5iZS96OVV6MWljandyTQo=")
+
+// archive archives chart to data
+func archive(chart *chart.Chart) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+
+	// Wrap in gzip writer
+	zipper := gzip.NewWriter(buf)
+	zipper.Header.Extra = headerBytes
+	zipper.Header.Comment = "Helm"
+
+	// Wrap in tar writer
+	twriter := tar.NewWriter(zipper)
+	err := writeTarContents(twriter, chart, "")
+
+	// It makes no sense when error occurs.
+	// But close before returning for obeying code convention.
+	// Don't defer the execution of Close().
+	twriter.Close()
+	zipper.Close()
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Unarchive unarchives data to chart
+func Unarchive(data []byte) (*chart.Chart, error) {
+	result, err := chartutil.LoadArchive(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// writeTarContents writes a chart to tar package
+// Copy from: k8s.io/helm/pkg/chartutil/save.go
+func writeTarContents(out *tar.Writer, c *chart.Chart, prefix string) error {
+	base := filepath.Join(prefix, c.Metadata.Name)
+
+	// Save Chart.yaml
+	cdata, err := yaml.Marshal(c.Metadata)
+	if err != nil {
+		return err
+	}
+	if err := writeToTar(out, base+"/Chart.yaml", cdata); err != nil {
+		return err
+	}
+
+	// Save values.yaml
+	if c.Values != nil && len(c.Values.Raw) > 0 {
+		if err := writeToTar(out, base+"/values.yaml", []byte(c.Values.Raw)); err != nil {
+			return err
+		}
+	}
+
+	// Save templates
+	for _, f := range c.Templates {
+		n := filepath.Join(base, f.Name)
+		if err := writeToTar(out, n, f.Data); err != nil {
+			return err
+		}
+	}
+
+	// Save files
+	for _, f := range c.Files {
+		n := filepath.Join(base, f.TypeUrl)
+		if err := writeToTar(out, n, f.Value); err != nil {
+			return err
+		}
+	}
+
+	// Save dependencies
+	for _, dep := range c.Dependencies {
+		if err := writeTarContents(out, dep, base+"/charts"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeToTar writes a single file to a tar archive.
+// Copy from: k8s.io/helm/pkg/chartutil/save.go
+func writeToTar(out *tar.Writer, name string, body []byte) error {
+	// TODO: Do we need to create dummy parent directory names if none exist?
+	h := &tar.Header{
+		Name: name,
+		Mode: 0755,
+		Size: int64(len(body)),
+	}
+	if err := out.WriteHeader(h); err != nil {
+		return err
+	}
+	if _, err := out.Write(body); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add create/delete/values commands


```
➜  bin git:(master) ./release-cli lint -t ../../charts/templates/1.0.0 -c ./release.yaml -s ./standard.yaml
E0419 14:22:27.029230    6670 lint.go:95] ._config.controllers[].services[].ports[].port has wrong type string, must be in [float64]
W0419 14:22:27.029263    6670 lint.go:83] ._config.controllers[].exas.asdd is not in standard
```

standard.yaml (from caicloud/charts):
```yaml
_config:
  _metadata:
    name: standard
    version: 1.0.0
    description: "Standard chart values"
    creationTime: "2017-07-14 12:00:00"
    source: "/library/template/1.0.0"
    revision: 1
    class: Default
    template:
      type: "template.caicloud.io/application"
      version: 1.0.0
  controllers:
  - type: ControllerType
    controller:
      replica: 1
      strategy:
        unavailable: 0
        surge: 1
      ready: 0
      name: "statefulsetname"
      domain: "servicedomain"
      parallelism: 1
      completions: 1
      active: 0
      rule: "*/1 * * * *"
      deadline: 0
      policy: "Allow"
      suspend: false
      history:
        success: 0
        fail: 0
      annotations:
      - key: "annotation key"
        value: "annotation value"
    schedule:
      scheduler: "schedulername"
      labels:
        name: somename
      affinity:
        node:
          type: Prefered
          terms:
          - weight: 10
            expressions:
            - key: somenodekey
              operator: NotIn
              values:
              - somenodevalue
        pod:
          type: Required
          terms:
          - weight: 10
            topologyKey: "kubernetes.io/hostname"
            namespaces:
            - default
            selector:
              labels:
                name: somename
              expressions:
              - key: name
                operator: NotIn
                values:
                - somename
      antiaffinity:
        pod:
          type: Required
          terms:
          - weight: 10
            topologyKey: "kubernetes.io/hostname"
            namespaces:
            - default
            selector:
              labels:
                name: somename
              expressions:
              - key: name
                operator: NotIn
                values:
                - somename
      tolerations:
      - key: "somenodekey"
        operator: "Equal"
        value: "somenodevalue"
        effect: "NoExecute"
        tolerationSeconds: 10
    pod:
      restart: Always
      dns: "ClusterFirst"
      hostname: "hostname"
      subdomain: "subdomain"
      termination: 30
      serviceAccountName: "serviceAccountName"
      host:
        network: true
        pid: false
        ipc: false
      annotations:
      - key: "podannotationkey"
        value: "podannotationvalue"
    initContainers:
    - name: "ic0"
      image: mysql-init:v1.0.0
      imagePullPolicy: Always
      tty: false
      command:
      - "./init"
      args:
      - "-c"
      workingDir: "/"
      privileged: false
      capabilities:
        add:
        - "Some"
        drop:
        - "Others"
      ports:
      - protocol: HTTP
        port: 80
        hostPort: 0
      envFrom:
      - type: Config
        name: someconfigmap
        prefix: XXXX_
        optional: false
      downwardPrefix: MY_ENV
      env:
      - name: SOME_ENV
        value: "env value"
        from:
          type: "Config"
          name: "someconfig"
          key: "configkey"
          optional: false
      resources:
        requests:
          cpu: 100m
          memory: 100Mi
          storage: 10Gi
          gpu: "1"
        limits:
          cpu: 100m
          memory: 100Mi
          storage: 10Gi
          gpu: "1"
      mounts:
      - name: db-volume
        readonly: false
        path: /var/lib/mysql
        subpath: "db"
      probe:
        liveness:
          handler:
            type: HTTP
            method:
              command:
              - test
              scheme: HTTPS
              host: "none"
              port: 443
              path: /liveness
              header:
              - name: "Some-Header"
                value: "value"
          delay: 10
          timeout: 1
          period: 10
          threshold:
            success: 1
            failure: 3
        readiness:
          handler:
            type: HTTP
            method:
              command:
              - test
              scheme: HTTPS
              host: "none"
              port: 443
              path: /liveness
              header:
              - name: "Some-Header"
                value: "value"
          delay: 10
          timeout: 1
          period: 10
          threshold:
            success: 1
            failure: 3
      lifecycle:
        postStart:
          type: HTTP
          method:
            command:
            - test
            scheme: HTTPS
            host: "none"
            port: 443
            path: /liveness
            header:
            - name: "Some-Header"
              value: "value"
        preStop:
          type: HTTP
          method:
            command:
            - test
            scheme: HTTPS
            host: "none"
            port: 443
            path: /liveness
            header:
            - name: "Some-Header"
              value: "value"
    containers:
    - name: "c0"
      image: mysql:v1.0.0
      imagePullPolicy: Always
      tty: false
      command:
      - "./init"
      args:
      - "-c"
      workingDir: "/"
      privileged: false
      capabilities:
        add:
        - "Some"
        drop:
        - "Others"
      ports:
      - protocol: HTTP
        port: 80
        hostPort: 0
      envFrom:
      - type: Config
        name: someconfigmap
        prefix: XXXX_
        optional: false
      downwardPrefix: MY_ENV
      env:
      - name: SOME_ENV
        value: "env value"
        from:
          type: "Config"
          name: "someconfig"
          key: "configkey"
          optional: false
      resources:
        requests:
          cpu: 100m
          memory: 100Mi
          storage: 10Gi
          gpu: "1"
        limits:
          cpu: 100m
          memory: 100Mi
          storage: 10Gi
          gpu: "1"
      mounts:
      - name: db-volume
        readonly: false
        path: /var/lib/mysql
        subpath: "db"
      probe:
        liveness:
          handler:
            type: HTTP
            method:
              command:
              - test
              scheme: HTTPS
              host: "none"
              port: 443
              path: /liveness
              header:
              - name: "Some-Header"
                value: "value"
          delay: 10
          timeout: 1
          period: 10
          threshold:
            success: 1
            failure: 3
        readiness:
          handler:
            type: HTTP
            method:
              command:
              - test
              scheme: HTTPS
              host: "none"
              port: 443
              path: /liveness
              header:
              - name: "Some-Header"
                value: "value"
          delay: 10
          timeout: 1
          period: 10
          threshold:
            success: 1
            failure: 3
      lifecycle:
        postStart:
          type: HTTP
          method:
            command:
            - test
            scheme: HTTPS
            host: "none"
            port: 443
            path: /liveness
            header:
            - name: "Some-Header"
              value: "value"
        preStop:
          type: HTTP
          method:
            command:
            - test
            scheme: HTTPS
            host: "none"
            port: 443
            path: /liveness
            header:
            - name: "Some-Header"
              value: "value"
    volumes:
    - name: db-volume
      type: Dedicated
      source:
        class: hdd
        modes:
        - ReadWriteOnce
        target: "pvcname"
        readonly: false
        medium: "memory"
        items:
        - key: "key"
          path: "path"
          mode: "0644"
        default: "0644"
        optional: false
        path: "/localpath"
      storage:
        request: 5Gi
        limit: 100Gi
    services:
    - name: mysql
      type: ClusterIP
      export: true
      ports:
      - protocol: HTTP
        targetPort: 80
        port: 80
        nodePort: 30000
      annotations:
      - key: "annotationkey"
        value: "annotationvalue"
    configs:
    - name: simplecfg
      data:
      - key: "config.yaml"
        value: |
          sync: "5m"
          deadline: "3h"
    secrets:
    - name: simplesecret
      type: Opaque
      data:
      - key: "encrypted.cfg"
        value: c3luYzogIjVtIgpkZWFkbGluZTogIjNoIgo=
```

**Which issue(s) this PR fixes** *(optional, close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

/cc @zoumo 
/cc @supereagle 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/docs/review_conventions.md  <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/docs/commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/docs/caicloud_bot.md        <-- how to work with caicloud bot

Other tips from Kubernetes cmomunity:

1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->
